### PR TITLE
AssertionHelper fully implemented, with tests to ensure this.

### DIFF
--- a/src/NUnit.StaticExpect.NetStd/NUnit.StaticExpect.NetStd.csproj
+++ b/src/NUnit.StaticExpect.NetStd/NUnit.StaticExpect.NetStd.csproj
@@ -24,10 +24,11 @@ And then use Expect() like you would have, without inheriting from AssertionHelp
     <Compile Include="..\NUnit.StaticExpect\Expectations.cs" Link="Expectations.cs" />
     <Compile Include="..\NUnit.StaticExpect\ExpectationsHas.cs" Link="ExpectationsHas.cs" />
     <Compile Include="..\NUnit.StaticExpect\ExpectationsIs.cs" Link="ExpectationsIs.cs" />
+    <Compile Include="..\NUnit.StaticExpect\ExpectationsMopUp.cs" Link="ExpectationsMopUp.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.7.1" />
+    <PackageReference Include="nunit" Version="3.8.1" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnit.StaticExpect.TestPackage/NUnit.StaticExpect.TestPackage.csproj
+++ b/src/NUnit.StaticExpect.TestPackage/NUnit.StaticExpect.TestPackage.csproj
@@ -30,11 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="NUnit.StaticExpect, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.StaticExpect.1.0.0\lib\net45\NUnit.StaticExpect.dll</HintPath>
+      <HintPath>..\packages\NUnit.StaticExpect.1.0.1\lib\net45\NUnit.StaticExpect.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -50,6 +50,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NUnit.StaticExpect.TestPackage/app.config
+++ b/src/NUnit.StaticExpect.TestPackage/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.8.1.0" newVersion="3.8.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/NUnit.StaticExpect.TestPackage/packages.config
+++ b/src/NUnit.StaticExpect.TestPackage/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.1" targetFramework="net452" />
-  <package id="NUnit.StaticExpect" version="1.0.0" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
+  <package id="NUnit.StaticExpect" version="1.0.1" targetFramework="net452" />
 </packages>

--- a/src/NUnit.StaticExpect.Tests/Extensions.cs
+++ b/src/NUnit.StaticExpect.Tests/Extensions.cs
@@ -58,7 +58,6 @@ namespace NUnit.StaticExpect.Tests
         {
             if (reference.IsGenericParameter && type.IsGenericParameter)
             {
-                Console.Write($"{reference.GenericParameterPosition} : {type.GenericParameterPosition}");
                 return reference.GenericParameterPosition == type.GenericParameterPosition;
             }
 

--- a/src/NUnit.StaticExpect.Tests/Extensions.cs
+++ b/src/NUnit.StaticExpect.Tests/Extensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NUnit.StaticExpect.Tests
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Searches for methods on the current type with the specified name and parameters.
+        /// This implementation uses <see cref="Similar(Type, Type)"/> to determine equality,
+        /// which copes better with generics than the library GetMethod() methods does.
+        /// </summary>
+        /// <param name="type">The type to search.</param>
+        /// <param name="name">The name of the method to search for.</param>
+        /// <param name="parameters">The parameters in the method signature.</param>
+        /// <param name="flags">A <see cref="BindingFlags"/> array with which to filter the search.</param>
+        /// <returns></returns>
+        public static MethodInfo GetMethodWithGenerics(
+                                    this Type type,
+                                    string name, Type[] parameters,
+                                    BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+        {
+            var methods = type.GetMethods(flags);
+
+            foreach (var method in methods)
+            {
+                var parmeterTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
+
+                if (method.Name == name && parmeterTypes.Count() == parameters.Length)
+                {
+                    bool match = true;
+
+                    for (int i = 0; i < parameters.Length; i++)
+                        match &= parmeterTypes[i].Similar(parameters[i]);
+
+                    if (match)
+                        return method;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Compares a type to the current one to see if they are "similar".
+        /// "Similarity" is based on the equality operator but compares on
+        /// Type.GenericTypeDefinition if Type.IsGenericType is true and
+        /// generic parameter positions if they are both generic parameters.
+        /// </summary>
+        /// <param name="reference">The reference.</param>
+        /// <param name="type">The type.</param>
+        /// <returns>True if types are similar, false otherwise</returns>
+        public static bool Similar(this Type reference, Type type)
+        {
+            if (reference.IsGenericParameter && type.IsGenericParameter)
+            {
+                Console.Write($"{reference.GenericParameterPosition} : {type.GenericParameterPosition}");
+                return reference.GenericParameterPosition == type.GenericParameterPosition;
+            }
+
+            return ComparableType(reference) == ComparableType(type);
+
+            Type ComparableType(Type cType)
+                => cType.IsGenericType ? cType.GetGenericTypeDefinition() : cType;
+        }
+
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/NUnit.StaticExpect.Tests.csproj
+++ b/src/NUnit.StaticExpect.Tests/NUnit.StaticExpect.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnit.StaticExpect.Tests</RootNamespace>
     <AssemblyName>NUnit.StaticExpect.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -34,8 +34,8 @@
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="PeanutButter.RandomGenerators, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PeanutButter.RandomGenerators.1.2.162\lib\net45\PeanutButter.RandomGenerators.dll</HintPath>
@@ -51,9 +51,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -62,8 +59,20 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
+    <Compile Include="TestAssertionHelper_OriginalTests.cs" />
     <Compile Include="TestExpect.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestExpect_AssertionHelperCompatibility.cs" />
+    <Compile Include="TestUtilities_Comparers\AlwaysEqualComparer.cs" />
+    <Compile Include="TestUtilities_Comparers\GenericComparer.cs" />
+    <Compile Include="TestUtilities_Comparers\GenericComparison.cs" />
+    <Compile Include="TestUtilities_Comparers\GenericEqualityComparer.cs" />
+    <Compile Include="TestUtilities_Comparers\GenericEqualityComparison.cs" />
+    <Compile Include="TestUtilities_Comparers\ObjectComparer.cs" />
+    <Compile Include="TestUtilities_Comparers\ObjectEqualityComparer.cs" />
+    <Compile Include="TestUtilities_Comparers\ObjectToStringComparer.cs" />
+    <Compile Include="TestUtilities_Comparers\TestComparer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -74,6 +83,9 @@
       <Project>{04166088-e42d-49d2-8c86-11b3b7013f2e}</Project>
       <Name>NUnit.StaticExpect</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NUnit.StaticExpect.Tests/TestAssertionHelper_OriginalTests.cs
+++ b/src/NUnit.StaticExpect.Tests/TestAssertionHelper_OriginalTests.cs
@@ -1,0 +1,941 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using NUnit.TestUtilities.Comparers;
+
+using static NUnit.StaticExpect.Expectations;
+
+namespace NUnit.StaticExpect.Tests
+{
+    [SuppressMessage("Microsoft.Design", "CS0618:Obsolete")]
+    class TestAssertionHelper_OriginalTests
+    {
+        class AssertionHelperTests
+        {
+            private static readonly string DEFAULT_PATH_CASE = Path.DirectorySeparatorChar == '\\' ? "ignorecase" : "respectcase";
+
+            #region Not
+
+            [Test]
+            public void NotNull()
+            {
+                var expression = Not.Null;
+                Expect(expression, TypeOf<NullConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo("<not <null>>"));
+            }
+
+            [Test]
+            public void NotNotNotNull()
+            {
+                var expression = Not.Not.Not.Null;
+                Expect(expression, TypeOf<NullConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo("<not <not <not <null>>>>"));
+            }
+
+            #endregion
+
+            #region All
+
+            [Test]
+            public void AllItems()
+            {
+                var expression = All.GreaterThan(0);
+                Expect(expression, TypeOf<GreaterThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AllItemsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<all <greaterthan 0>>"));
+            }
+
+            #endregion
+
+            #region Some
+
+            [Test]
+            public void Some_EqualTo()
+            {
+                var expression = Some.EqualTo(3);
+                Expect(expression, TypeOf<EqualConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<SomeItemsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<some <equal 3>>"));
+            }
+
+            [Test]
+            public void Some_BeforeBinaryOperators()
+            {
+                var expression = Some.GreaterThan(0).And.LessThan(100).Or.EqualTo(999);
+                Expect(expression, TypeOf<EqualConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<SomeItemsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<some <or <and <greaterthan 0> <lessthan 100>> <equal 999>>>"));
+            }
+
+            [Test]
+            public void Some_Nested()
+            {
+                var expression = Some.With.Some.LessThan(100);
+                Expect(expression, TypeOf<LessThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<SomeItemsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<some <some <lessthan 100>>>"));
+            }
+
+            [Test]
+            public void Some_AndSome()
+            {
+                var expression = Some.GreaterThan(0).And.Some.LessThan(100);
+                Expect(expression, TypeOf<LessThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AndConstraint>());
+                Expect(constraint.ToString(), EqualTo("<and <some <greaterthan 0>> <some <lessthan 100>>>"));
+            }
+
+            #endregion
+
+            #region None
+
+            [Test]
+            public void NoItems()
+            {
+                var expression = None.LessThan(0);
+                Expect(expression, TypeOf<LessThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NoItemConstraint>());
+                Expect(constraint.ToString(), EqualTo("<none <lessthan 0>>"));
+            }
+
+            #endregion
+
+            #region Property
+
+            [Test]
+            public void Property_Test()
+            {
+                var expression = Property("X");
+                Expect(expression, TypeOf<ResolvableConstraintExpression>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<PropertyExistsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<propertyexists X>"));
+            }
+
+            [Test]
+            public void Property_FollowedByAnd()
+            {
+                var expression = Property("X").And.EqualTo(7);
+                Expect(expression, TypeOf<EqualConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AndConstraint>());
+                Expect(constraint.ToString(), EqualTo("<and <propertyexists X> <equal 7>>"));
+            }
+
+            [Test]
+            public void Property_FollowedByConstraint()
+            {
+                var expression = Property("X").GreaterThan(5);
+                Expect(expression, TypeOf<GreaterThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<PropertyConstraint>());
+                Expect(constraint.ToString(), EqualTo("<property X <greaterthan 5>>"));
+            }
+
+            [Test]
+            public void Property_FollowedByNot()
+            {
+                var expression = Property("X").Not.GreaterThan(5);
+                Expect(expression, TypeOf<GreaterThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<PropertyConstraint>());
+                Expect(constraint.ToString(), EqualTo("<property X <not <greaterthan 5>>>"));
+            }
+
+            [Test]
+            public void LengthProperty()
+            {
+                var expression = Length.GreaterThan(5);
+                Expect(expression, TypeOf<GreaterThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<PropertyConstraint>());
+                Expect(constraint.ToString(), EqualTo("<property Length <greaterthan 5>>"));
+            }
+
+            [Test]
+            public void CountProperty()
+            {
+                var expression = Count.EqualTo(5);
+                Expect(expression, TypeOf<EqualConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<PropertyConstraint>());
+                Expect(constraint.ToString(), EqualTo("<property Count <equal 5>>"));
+            }
+
+            [Test]
+            public void MessageProperty()
+            {
+                var expression = Message.StartsWith("Expected");
+                Expect(expression, TypeOf<StartsWithConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<PropertyConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<property Message <startswith ""Expected"">>"));
+            }
+
+            #endregion
+
+            #region Attribute
+
+            [Test]
+            public void AttributeExistsTest()
+            {
+                var expression = Attribute(typeof(TestFixtureAttribute));
+                Expect(expression, TypeOf<ResolvableConstraintExpression>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AttributeExistsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<attributeexists NUnit.Framework.TestFixtureAttribute>"));
+            }
+
+            [Test]
+            public void AttributeTest_FollowedByConstraint()
+            {
+                var expression = Attribute(typeof(TestFixtureAttribute)).Property("Description").Not.Null;
+                Expect(expression, TypeOf<NullConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AttributeConstraint>());
+                Expect(constraint.ToString(), EqualTo("<attribute NUnit.Framework.TestFixtureAttribute <property Description <not <null>>>>"));
+            }
+
+            [Test]
+            public void AttributeExistsTest_Generic()
+            {
+                var expression = Attribute<TestFixtureAttribute>();
+                Expect(expression, TypeOf<ResolvableConstraintExpression>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AttributeExistsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<attributeexists NUnit.Framework.TestFixtureAttribute>"));
+            }
+
+            [Test]
+            public void AttributeTest_FollowedByConstraint_Generic()
+            {
+                var expression = Attribute<TestFixtureAttribute>().Property("Description").Not.Null;
+                Expect(expression, TypeOf<NullConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AttributeConstraint>());
+                Expect(constraint.ToString(), EqualTo("<attribute NUnit.Framework.TestFixtureAttribute <property Description <not <null>>>>"));
+            }
+
+            #endregion
+
+            #region Null
+
+            [Test]
+            public void NullTest()
+            {
+                var constraint = Null;
+                Expect(constraint, TypeOf<NullConstraint>());
+                Expect(constraint.ToString(), EqualTo("<null>"));
+            }
+
+            #endregion
+
+            #region True
+
+            [Test]
+            public void TrueTest()
+            {
+                var constraint = True;
+                Expect(constraint, TypeOf<TrueConstraint>());
+                Expect(constraint.ToString(), EqualTo("<true>"));
+            }
+
+            #endregion
+
+            #region False
+
+            [Test]
+            public void FalseTest()
+            {
+                var constraint = False;
+                Expect(constraint, TypeOf<FalseConstraint>());
+                Expect(constraint.ToString(), EqualTo("<false>"));
+            }
+
+            #endregion
+
+            #region Positive
+
+            [Test]
+            public void PositiveTest()
+            {
+                var constraint = Positive;
+                Expect(constraint, TypeOf<GreaterThanConstraint>());
+                Expect(constraint.ToString(), EqualTo("<greaterthan 0>"));
+            }
+
+            #endregion
+
+            #region Negative
+
+            [Test]
+            public void NegativeTest()
+            {
+                var constraint = Negative;
+                Expect(constraint, TypeOf<LessThanConstraint>());
+                Expect(constraint.ToString(), EqualTo("<lessthan 0>"));
+            }
+
+            #endregion
+
+            #region Zero
+
+            [Test]
+            public void ZeroTest()
+            {
+                var constraint = Zero;
+                Expect(constraint, TypeOf<EqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<equal 0>"));
+            }
+
+            #endregion
+
+            #region NaN
+
+            [Test]
+            public void NaNTest()
+            {
+                var constraint = NaN;
+                Expect(constraint, TypeOf<NaNConstraint>());
+                Expect(constraint.ToString(), EqualTo("<nan>"));
+            }
+
+            #endregion
+
+            #region After
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+            [Test]
+            public void After()
+            {
+                var constraint = EqualTo(10).After(1000);
+                Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
+                Expect(constraint.ToString(), EqualTo("<after 1000 <equal 10>>"));
+            }
+
+            [Test]
+            public void After_Property()
+            {
+                var constraint = Property("X").EqualTo(10).After(1000);
+                Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
+                Expect(constraint.ToString(), EqualTo("<after 1000 <property X <equal 10>>>"));
+            }
+
+            [Test]
+            public void After_And()
+            {
+                var constraint = GreaterThan(0).And.LessThan(10).After(1000);
+                Expect(constraint, TypeOf<DelayedConstraint.WithRawDelayInterval>());
+                Expect(constraint.ToString(), EqualTo("<after 1000 <and <greaterthan 0> <lessthan 10>>>"));
+            }
+#endif
+
+            #endregion
+
+            #region Unique
+
+            [Test]
+            public void UniqueItems()
+            {
+                var constraint = Unique;
+                Expect(constraint, TypeOf<UniqueItemsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<uniqueitems>"));
+            }
+
+            #endregion
+
+            #region Ordered
+
+            [Test]
+            public void CollectionOrdered()
+            {
+                var constraint = Ordered;
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<ordered>"));
+            }
+
+            [Test]
+            public void CollectionOrdered_Descending()
+            {
+                var constraint = Ordered.Descending;
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<ordered descending>"));
+            }
+
+            [Test]
+            public void CollectionOrdered_Comparer()
+            {
+                var constraint = Ordered.Using(ObjectComparer.Default);
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<ordered NUnit.TestUtilities.Comparers.ObjectComparer>"));
+            }
+
+            [Test]
+            public void CollectionOrdered_Comparer_Descending()
+            {
+                var constraint = Ordered.Using(ObjectComparer.Default).Descending;
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<ordered descending NUnit.TestUtilities.Comparers.ObjectComparer>"));
+            }
+
+            #endregion
+
+            #region OrderedBy
+
+            [Test]
+            public void CollectionOrderedBy()
+            {
+                var constraint = Ordered.By("SomePropertyName");
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName>"));
+            }
+
+            [Test]
+            public void CollectionOrderedBy_Descending()
+            {
+                var constraint = Ordered.By("SomePropertyName").Descending;
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName descending>"));
+            }
+
+            [Test]
+            public void CollectionOrderedBy_Comparer()
+            {
+                var constraint = Ordered.By("SomePropertyName").Using(ObjectComparer.Default);
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName NUnit.TestUtilities.Comparers.ObjectComparer>"));
+            }
+
+            [Test]
+            public void CollectionOrderedBy_Comparer_Descending()
+            {
+                var constraint = Ordered.By("SomePropertyName").Using(ObjectComparer.Default).Descending;
+                Expect(constraint, TypeOf<CollectionOrderedConstraint>());
+                Expect(constraint.ToString(), EqualTo("<orderedby SomePropertyName descending NUnit.TestUtilities.Comparers.ObjectComparer>"));
+            }
+
+            #endregion
+
+            #region Contains
+
+            [Test]
+            public void ContainsConstraint()
+            {
+                var constraint = Contains(42);
+                Expect(constraint, TypeOf<EqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<unresolved <equal 42>>"));
+            }
+
+            #endregion
+
+            #region SubsetOf
+
+            [Test]
+            public void SubsetOfConstraint()
+            {
+                var constraint = SubsetOf(new int[] { 1, 2, 3 });
+                Expect(constraint, TypeOf<CollectionSubsetConstraint>());
+                Expect(constraint.ToString(), EqualTo("<subsetof System.Int32[]>"));
+            }
+
+            #endregion
+
+            #region EquivalentTo
+
+            [Test]
+            public void EquivalentConstraint()
+            {
+                var constraint = EquivalentTo(new int[] { 1, 2, 3 });
+                Expect(constraint, TypeOf<CollectionEquivalentConstraint>());
+                Expect(constraint.ToString(), EqualTo("<equivalent System.Int32[]>"));
+            }
+
+            #endregion
+
+            #region ComparisonConstraints
+
+            [Test]
+            public void GreaterThan_Test()
+            {
+                var constraint = GreaterThan(7);
+                Expect(constraint, TypeOf<GreaterThanConstraint>());
+                Expect(constraint.ToString(), EqualTo("<greaterthan 7>"));
+            }
+
+            [Test]
+            public void GreaterThanOrEqual()
+            {
+                var constraint = GreaterThanOrEqualTo(7);
+                Expect(constraint, TypeOf<GreaterThanOrEqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<greaterthanorequal 7>"));
+            }
+
+            [Test]
+            public void AtLeast_Test()
+            {
+                var constraint = AtLeast(7);
+                Expect(constraint, TypeOf<GreaterThanOrEqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<greaterthanorequal 7>"));
+            }
+
+            [Test]
+            public void LessThan_Test()
+            {
+                var constraint = LessThan(7);
+                Expect(constraint, TypeOf<LessThanConstraint>());
+                Expect(constraint.ToString(), EqualTo("<lessthan 7>"));
+            }
+
+            [Test]
+            public void LessThanOrEqual()
+            {
+                var constraint = LessThanOrEqualTo(7);
+                Expect(constraint, TypeOf<LessThanOrEqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<lessthanorequal 7>"));
+            }
+
+            [Test]
+            public void AtMost_Test()
+            {
+                var constraint = AtMost(7);
+                Expect(constraint, TypeOf<LessThanOrEqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<lessthanorequal 7>"));
+            }
+
+            #endregion
+
+            #region EqualTo
+
+            [Test]
+            public void EqualConstraint()
+            {
+                var constraint = EqualTo(999);
+                Expect(constraint, TypeOf<EqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<equal 999>"));
+            }
+
+            [Test]
+            public void Equal_IgnoreCase()
+            {
+                var constraint = EqualTo("X").IgnoreCase;
+                Expect(constraint, TypeOf<EqualConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<equal ""X"">"));
+            }
+
+            [Test]
+            public void Equal_WithinTolerance()
+            {
+                var constraint = EqualTo(0.7).Within(.005);
+                Expect(constraint, TypeOf<EqualConstraint>());
+                Expect(constraint.ToString(), EqualTo("<equal 0.7>"));
+            }
+
+            #endregion
+
+            #region And
+
+            [Test]
+            public void AndConstraint()
+            {
+                var expression = GreaterThan(5).And.LessThan(10);
+                Expect(expression, TypeOf<LessThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AndConstraint>());
+                Expect(constraint.ToString(), EqualTo("<and <greaterthan 5> <lessthan 10>>"));
+            }
+
+            [Test]
+            public void AndConstraint_ThreeAndsWithNot()
+            {
+                var expression = Not.Null.And.Not.LessThan(5).And.Not.GreaterThan(10);
+                Expect(expression, TypeOf<GreaterThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<AndConstraint>());
+                Expect(constraint.ToString(), EqualTo("<and <not <null>> <and <not <lessthan 5>> <not <greaterthan 10>>>>"));
+            }
+
+            #endregion
+
+            #region Or
+
+            [Test]
+            public void OrConstraint()
+            {
+                var expression = LessThan(5).Or.GreaterThan(10);
+                Expect(expression, TypeOf<GreaterThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<OrConstraint>());
+                Expect(constraint.ToString(), EqualTo("<or <lessthan 5> <greaterthan 10>>"));
+            }
+
+            [Test]
+            public void OrConstraint_ThreeOrs()
+            {
+                var expression = LessThan(5).Or.GreaterThan(10).Or.EqualTo(7);
+                Expect(expression, TypeOf<EqualConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<OrConstraint>());
+                Expect(constraint.ToString(), EqualTo("<or <lessthan 5> <or <greaterthan 10> <equal 7>>>"));
+            }
+
+            [Test]
+            public void OrConstraint_PrecededByAnd()
+            {
+                var expression = LessThan(100).And.GreaterThan(0).Or.EqualTo(999);
+                Expect(expression, TypeOf<EqualConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<OrConstraint>());
+                Expect(constraint.ToString(), EqualTo("<or <and <lessthan 100> <greaterthan 0>> <equal 999>>"));
+            }
+
+            [Test]
+            public void OrConstraint_FollowedByAnd()
+            {
+                var expression = EqualTo(999).Or.GreaterThan(0).And.LessThan(100);
+                Expect(expression, TypeOf<LessThanConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<OrConstraint>());
+                Expect(constraint.ToString(), Is.EqualTo("<or <equal 999> <and <greaterthan 0> <lessthan 100>>>"));
+            }
+
+            #endregion
+
+            #region SamePath
+
+            [Test]
+            public void SamePath_Test()
+            {
+                var constraint = SamePath("/path/to/match");
+                Expect(constraint, TypeOf<SamePathConstraint>());
+                Expect(constraint.ToString(), EqualTo(
+                    string.Format(@"<samepath ""/path/to/match"" {0}>", DEFAULT_PATH_CASE)));
+            }
+
+            [Test]
+            public void SamePath_IgnoreCase()
+            {
+                var constraint = SamePath("/path/to/match").IgnoreCase;
+                Expect(constraint, TypeOf<SamePathConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<samepath ""/path/to/match"" ignorecase>"));
+            }
+
+            [Test]
+            public void NotSamePath_IgnoreCase()
+            {
+                var expression = Not.SamePath("/path/to/match").IgnoreCase;
+                Expect(expression, TypeOf<SamePathConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<not <samepath ""/path/to/match"" ignorecase>>"));
+            }
+
+            [Test]
+            public void SamePath_RespectCase()
+            {
+                var constraint = SamePath("/path/to/match").RespectCase;
+                Expect(constraint, TypeOf<SamePathConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<samepath ""/path/to/match"" respectcase>"));
+            }
+
+            [Test]
+            public void NotSamePath_RespectCase()
+            {
+                var expression = Not.SamePath("/path/to/match").RespectCase;
+                Expect(expression, TypeOf<SamePathConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<not <samepath ""/path/to/match"" respectcase>>"));
+            }
+
+            #endregion
+
+            #region SamePathOrUnder
+
+            [Test]
+            public void SamePathOrUnder_Test()
+            {
+                var constraint = SamePathOrUnder("/path/to/match");
+                Expect(constraint, TypeOf<SamePathOrUnderConstraint>());
+                Expect(constraint.ToString(), EqualTo(
+                    string.Format(@"<samepathorunder ""/path/to/match"" {0}>", DEFAULT_PATH_CASE)));
+            }
+
+            [Test]
+            public void SamePathOrUnder_IgnoreCase()
+            {
+                var constraint = SamePathOrUnder("/path/to/match").IgnoreCase;
+                Expect(constraint, TypeOf<SamePathOrUnderConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<samepathorunder ""/path/to/match"" ignorecase>"));
+            }
+
+            [Test]
+            public void NotSamePathOrUnder_IgnoreCase()
+            {
+                var expression = Not.SamePathOrUnder("/path/to/match").IgnoreCase;
+                Expect(expression, TypeOf<SamePathOrUnderConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<not <samepathorunder ""/path/to/match"" ignorecase>>"));
+            }
+
+            [Test]
+            public void SamePathOrUnder_RespectCase()
+            {
+                var constraint = SamePathOrUnder("/path/to/match").RespectCase;
+                Expect(constraint, TypeOf<SamePathOrUnderConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<samepathorunder ""/path/to/match"" respectcase>"));
+            }
+
+            [Test]
+            public void NotSamePathOrUnder_RespectCase()
+            {
+                var expression = Not.SamePathOrUnder("/path/to/match").RespectCase;
+                Expect(expression, TypeOf<SamePathOrUnderConstraint>());
+                var constraint = Resolve(expression);
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<not <samepathorunder ""/path/to/match"" respectcase>>"));
+            }
+
+            #endregion
+
+            #region BinarySerializable
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+            [Test]
+            public void BinarySerializableConstraint()
+            {
+                var constraint = BinarySerializable;
+                Expect(constraint, TypeOf<BinarySerializableConstraint>());
+                Expect(constraint.ToString(), EqualTo("<binaryserializable>"));
+            }
+#endif
+
+            #endregion
+
+            #region XmlSerializable
+
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+            [Test]
+            public void XmlSerializableConstraint()
+            {
+                var constraint = XmlSerializable;
+                Expect(constraint, TypeOf<XmlSerializableConstraint>());
+                Expect(constraint.ToString(), EqualTo("<xmlserializable>"));
+            }
+#endif
+
+            #endregion
+
+            #region Contains
+
+            [Test]
+            public void ContainsTest()
+            {
+                var constraint = Contains("X");
+                Expect(constraint, TypeOf<ContainsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<contains>"));
+            }
+
+            [Test]
+            public void ContainsTest_IgnoreCase()
+            {
+                var constraint = Contains("X").IgnoreCase;
+                Expect(constraint, TypeOf<ContainsConstraint>());
+                Expect(constraint.ToString(), EqualTo("<contains>"));
+            }
+
+            #endregion
+
+            #region StartsWith
+
+            [Test]
+            public void StartsWithTest()
+            {
+                var constraint = StartsWith("X");
+                Expect(constraint, TypeOf<StartsWithConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<startswith ""X"">"));
+            }
+
+            [Test]
+            public void StartsWithTest_IgnoreCase()
+            {
+                var constraint = StartsWith("X").IgnoreCase;
+                Expect(constraint, TypeOf<StartsWithConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<startswith ""X"">"));
+            }
+
+            #endregion
+
+            #region EndsWith
+
+            [Test]
+            public void EndsWithTest()
+            {
+                var constraint = EndsWith("X");
+                Expect(constraint, TypeOf<EndsWithConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<endswith ""X"">"));
+            }
+
+            [Test]
+            public void EndsWithTest_IgnoreCase()
+            {
+                var constraint = EndsWith("X").IgnoreCase;
+                Expect(constraint, TypeOf<EndsWithConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<endswith ""X"">"));
+            }
+
+            #endregion
+
+            #region Matches
+
+            [Test]
+            public void MatchesTest()
+            {
+                var constraint = Matches("X");
+                Expect(constraint, TypeOf<RegexConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<regex ""X"">"));
+            }
+
+            [Test]
+            public void MatchesTest_IgnoreCase()
+            {
+                var constraint = Matches("X").IgnoreCase;
+                Expect(constraint, TypeOf<RegexConstraint>());
+                Expect(constraint.ToString(), EqualTo(@"<regex ""X"">"));
+            }
+
+            #endregion
+
+            #region TypeOf
+
+            [Test]
+            public void TypeOfTest()
+            {
+                var constraint = TypeOf(typeof(string));
+                Expect(constraint, TypeOf<ExactTypeConstraint>());
+                Expect(constraint.ToString(), EqualTo("<typeof System.String>"));
+            }
+
+            [Test]
+            public void TypeOfTest_Generic()
+            {
+                var constraint = TypeOf<string>();
+                Expect(constraint, TypeOf<ExactTypeConstraint>());
+                Expect(constraint.ToString(), EqualTo("<typeof System.String>"));
+            }
+
+            #endregion
+
+            #region InstanceOf
+
+            [Test]
+            public void InstanceOfTest()
+            {
+                var constraint = InstanceOf(typeof(string));
+                Expect(constraint, TypeOf<InstanceOfTypeConstraint>());
+                Expect(constraint.ToString(), EqualTo("<instanceof System.String>"));
+            }
+
+            [Test]
+            public void InstanceOfTest_Generic()
+            {
+                var constraint = InstanceOf<string>();
+                Expect(constraint, TypeOf<InstanceOfTypeConstraint>());
+                Expect(constraint.ToString(), EqualTo("<instanceof System.String>"));
+            }
+
+            #endregion
+
+            #region AssignableFrom
+
+            [Test]
+            public void AssignableFromTest()
+            {
+                var constraint = AssignableFrom(typeof(string));
+                Expect(constraint, TypeOf<AssignableFromConstraint>());
+                Expect(constraint.ToString(), EqualTo("<assignablefrom System.String>"));
+            }
+
+            [Test]
+            public void AssignableFromTest_Generic()
+            {
+                var constraint = AssignableFrom<string>();
+                Expect(constraint, TypeOf<AssignableFromConstraint>());
+                Expect(constraint.ToString(), EqualTo("<assignablefrom System.String>"));
+            }
+
+            #endregion
+
+            #region AssignableTo
+
+            [Test]
+            public void AssignableToTest()
+            {
+                var constraint = AssignableTo(typeof(string));
+                Expect(constraint, TypeOf<AssignableToConstraint>());
+                Expect(constraint.ToString(), EqualTo("<assignableto System.String>"));
+            }
+
+            [Test]
+            public void AssignableToTest_Generic()
+            {
+                var constraint = AssignableTo<string>();
+                Expect(constraint, TypeOf<AssignableToConstraint>());
+                Expect(constraint.ToString(), EqualTo("<assignableto System.String>"));
+            }
+
+            #endregion
+
+            #region Operator Overrides
+
+            [Test]
+            public void NotOperator()
+            {
+                var constraint = !Null;
+                Expect(constraint, TypeOf<NotConstraint>());
+                Expect(constraint.ToString(), EqualTo("<not <null>>"));
+            }
+
+            [Test]
+            public void AndOperator()
+            {
+                var constraint = GreaterThan(5) & LessThan(10);
+                Expect(constraint, TypeOf<AndConstraint>());
+                Expect(constraint.ToString(), EqualTo("<and <greaterthan 5> <lessthan 10>>"));
+            }
+
+            [Test]
+            public void OrOperator()
+            {
+                var constraint = LessThan(5) | GreaterThan(10);
+                Expect(constraint, TypeOf<OrConstraint>());
+                Expect(constraint.ToString(), EqualTo("<or <lessthan 5> <greaterthan 10>>"));
+            }
+
+            #endregion
+
+            #region Helper Methods
+
+            private static IConstraint Resolve(IResolveConstraint expression)
+            {
+                return ((IResolveConstraint)expression).Resolve();
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestExpect_AssertionHelperCompatibility.cs
+++ b/src/NUnit.StaticExpect.Tests/TestExpect_AssertionHelperCompatibility.cs
@@ -1,0 +1,122 @@
+﻿using NUnit.Framework;
+using PeanutButter.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NUnit.StaticExpect.Tests
+{
+    [SuppressMessage("Microsoft.Design", "CS0618:Obsolete")]
+    [TestFixture]
+    public class TestExpect_AssertionHelperCompatibility
+    {
+        [TestCaseSource(nameof(GetAssertionHelperMethodSigs))]
+        public void ShouldImplementMethod_(Signature sig)
+        {
+            var member = FindMethod(typeof(Expectations), sig);
+
+            Assert.That(member, Is.Not.Null, $"{sig.Name} not found on Expectations");
+            Assert.That(member.ReturnType.Name, Is.EqualTo(sig.ReturnType.Name), $"{sig.Name}: return types don't match");
+        }
+
+        [TestCaseSource(nameof(GetAssertionHelperPropertySigs))]
+        public void ShouldImplementProperty_(Signature sig)
+        {
+            var member = FindProperty(typeof(Expectations), sig);
+
+            Assert.That(member, Is.Not.Null, $"{sig.Name} not found on Expectations");
+        }
+
+        private MethodInfo FindMethod(Type type, Signature sig)
+        {
+            // As a method
+            MethodInfo member = type.GetMethodWithGenerics(
+                                        sig.Name,
+                                        sig.ParameterTypes.ToArray(),
+                                        BindingFlags.Public | BindingFlags.Static);
+            if (member != null)
+                return member;
+
+            // Could also be a static property pass-through to a Func<>
+            var propinfo = type.GetProperty(sig.Name)?.GetValue(null);
+
+            // GetPropertyValue throws if member not found - we just want to return null
+            try { member = (MethodInfo)propinfo?.GetPropertyValue("Method"); }
+            catch (MemberNotFoundException) { return null; }
+
+            // Check parameter types match (compared on names)
+            Assert.That(member.GetParameters().Select(mi => mi.ParameterType.Name),
+                            Is.EqualTo(sig.ParameterTypes.Select(mi => mi.Name)),
+                            $"{sig.Name} implemented as pass-through property, but parameter types don't match.");
+            return member;
+        }
+
+        private PropertyInfo FindProperty(Type type, Signature sig)
+            => type.GetProperty(
+                            sig.Name,
+                            BindingFlags.Public | BindingFlags.Static,
+                            null,
+                            sig.ReturnType,
+                            sig.ParameterTypes.ToArray(),
+                            null);
+
+        private static IEnumerable<Signature> GetAssertionHelperMethodSigs()
+            => GetMethodSigs(typeof(AssertionHelper));
+
+        private static IEnumerable<Signature> GetAssertionHelperPropertySigs()
+            => GetPropertySigs(typeof(AssertionHelper));
+
+        private static IEnumerable<Signature> GetMethodSigs(Type type)
+        {
+            // Get MethodInfos, filter and project into signatures
+            var sigs = type.GetMethods(
+                                  BindingFlags.Public
+                                | BindingFlags.DeclaredOnly
+                                | BindingFlags.Static 
+                                | BindingFlags.Instance)
+                            .Where(mi => !mi.Name.StartsWith("get_"))
+                            .Where(mi => !mi.Name.StartsWith("set_"))
+                            .Select(o => new Signature(o.Name, o.ReturnType, o.GetParameters().Select(pi => pi.ParameterType)));
+
+            return sigs;
+        }
+
+        private static IEnumerable<Signature> GetPropertySigs(Type type)
+        {
+            var properties = type.GetProperties(
+                                    BindingFlags.Public
+                                    | BindingFlags.DeclaredOnly
+                                    | BindingFlags.Static
+                                    | BindingFlags.Instance)
+                                .Select(pi => new Signature(
+                                                    pi.Name,
+                                                    pi.PropertyType,
+                                                    pi.GetIndexParameters().Select(pr => pr.ParameterType)));
+
+            return properties;
+        }
+
+        public struct Signature
+        {
+            public string Name;
+            public Type ReturnType;
+            public IEnumerable<Type> ParameterTypes;
+
+            public Signature(string name, Type returnType, IEnumerable<Type> parameterTypes = null)
+            {
+                Name = name;
+                ReturnType = returnType;
+                ParameterTypes = parameterTypes;
+            }
+
+            // Used in automatic test naming - parameters ensure overrides register
+            public override string ToString()
+                => $"{Name}({String.Join(", ", ParameterTypes.Select(p => p.Name))})";
+        }
+    }
+
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/AlwaysEqualComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/AlwaysEqualComparer.cs
@@ -1,0 +1,41 @@
+﻿// ***********************************************************************
+// Copyright (c) 2006 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    internal class AlwaysEqualComparer : IComparer
+    {
+        public int CallCount = 0;
+
+        int IComparer.Compare(object x, object y)
+        {
+            CallCount++;
+
+            // This comparer ALWAYS returns zero (equal)!
+            return 0;
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericComparer.cs
@@ -1,0 +1,43 @@
+﻿// ***********************************************************************
+// Copyright (c) 2013 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    /// <summary>
+    /// GenericComparer is used in testing to ensure that only
+    /// the <see cref="IComparer{T}"/> interface is used.
+    /// </summary>
+    public class GenericComparer<T> : IComparer<T>
+    {
+        public bool WasCalled = false;
+
+        int IComparer<T>.Compare(T x, T y)
+        {
+            WasCalled = true;
+            return Comparer<T>.Default.Compare(x, y);
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericComparison.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericComparison.cs
@@ -1,0 +1,45 @@
+﻿// ***********************************************************************
+// Copyright (c) 2013 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    internal class GenericComparison<T>
+    {
+        public bool WasCalled = false;
+
+        public Comparison<T> Delegate
+        {
+            get { return new Comparison<T>(Compare); }
+        }
+
+        public int Compare(T x, T y)
+        {
+            WasCalled = true;
+            return Comparer<T>.Default.Compare(x, y);
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericEqualityComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericEqualityComparer.cs
@@ -1,0 +1,47 @@
+﻿// ***********************************************************************
+// Copyright (c) 2013 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    /// <summary>
+    /// GenericEqualityComparer is used in testing to ensure that only
+    /// the <see cref="IEqualityComparer{T}"/> interface is used.
+    /// </summary>
+    public class GenericEqualityComparer<T> : IEqualityComparer<T>
+    {
+        public bool WasCalled;
+
+        bool IEqualityComparer<T>.Equals(T x, T y)
+        {
+            WasCalled = true;
+            return Comparer<T>.Default.Compare(x, y) == 0;
+        }
+
+        int IEqualityComparer<T>.GetHashCode(T x)
+        {
+            return x.GetHashCode();
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericEqualityComparison.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/GenericEqualityComparison.cs
@@ -1,0 +1,43 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    internal class GenericEqualityComparison<T>
+    {
+        public bool WasCalled = false;
+
+        public Func<T, T, bool> Delegate
+        {
+            get { return new Func<T, T, bool>(Compare); }
+        }
+
+        public bool Compare(T x, T y)
+        {
+            WasCalled = true;
+            return x.Equals(y);
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/ObjectComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/ObjectComparer.cs
@@ -1,0 +1,48 @@
+﻿// ***********************************************************************
+// Copyright (c) 2013 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    /// <summary>
+    /// ObjectComparer is used in testing to ensure that only
+    /// methods of the IComparer interface are used.
+    /// </summary>
+    public class ObjectComparer : IComparer
+    {
+        public bool WasCalled = false;
+        public static readonly IComparer Default = new ObjectComparer();
+
+        int IComparer.Compare(object x, object y)
+        {
+            WasCalled = true;
+#if NETSTANDARD1_3 || NETSTANDARD1_6
+            return Comparer<object>.Default.Compare(x, y);
+#else
+            return Comparer.Default.Compare(x, y);
+#endif
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/ObjectEqualityComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/ObjectEqualityComparer.cs
@@ -1,0 +1,52 @@
+﻿// ***********************************************************************
+// Copyright (c) 2013 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    /// <summary>
+    /// ObjectEqualityComparer is used in testing to ensure that only
+    /// methods of the IEqualityComparer interface are used.
+    /// </summary>
+    public class ObjectEqualityComparer : IEqualityComparer
+    {
+        public bool Called;
+
+        bool IEqualityComparer.Equals(object x, object y)
+        {
+            Called = true;
+#if NETSTANDARD1_3 || NETSTANDARD1_6
+            return Comparer<object>.Default.Compare(x, y) == 0;
+#else
+            return Comparer.Default.Compare(x, y) == 0;
+#endif
+        }
+
+        int IEqualityComparer.GetHashCode(object x)
+        {
+            return x.GetHashCode();
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/ObjectToStringComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/ObjectToStringComparer.cs
@@ -1,0 +1,69 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    /// <summary>
+    /// ObjectToStringComparer is used in testing the <see cref="NUnit.Framework.Constraints.RangeConstraint"/> when the object does not implement the <see cref="IComparer"/>  interface.
+    /// Compares them as numbers when both arguments are <see cref="int"/>, else it uses <seealso cref="string.CompareTo(string)"/>.
+    /// </summary>
+    public class ObjectToStringComparer : System.Collections.IComparer
+    {
+        public bool WasCalled = false;
+        int System.Collections.IComparer.Compare(object x, object y)
+        {
+            WasCalled = true;
+            int intX = 0;
+            int intY = 0;
+
+            if(int.TryParse(x.ToString(), out intX) && int.TryParse(y.ToString(), out intY))
+            {
+                return intX.CompareTo(intY);
+            }
+
+            return x.ToString().CompareTo(y.ToString());
+
+        }
+    }
+
+    /// <summary>
+    /// NoComparer is a test class without implementing the IComparer interface.
+    /// Used to test the RangeConstraint.
+    /// </summary>
+    public class NoComparer
+    {
+        public readonly object _value;
+        public NoComparer(object value)
+        {
+            _value = value;
+        }
+        public override string ToString()
+        {
+            return _value.ToString();
+        }
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/TestComparer.cs
+++ b/src/NUnit.StaticExpect.Tests/TestUtilities_Comparers/TestComparer.cs
@@ -1,0 +1,51 @@
+﻿// ***********************************************************************
+// Copyright (c) 2006 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+
+namespace NUnit.TestUtilities.Comparers
+{
+    internal class TestComparer : IComparer
+    {
+        public int CallCount = 0;
+
+        #region IComparer Members
+        public int Compare(object x, object y)
+        {
+            CallCount++;
+
+            if (x == null && y == null)
+                return 0;
+
+            if (x == null || y == null)
+                return -1;
+
+            if (x.Equals(y))
+                return 0;
+
+            return -1;
+        }
+        #endregion
+    }
+}

--- a/src/NUnit.StaticExpect.Tests/app.config
+++ b/src/NUnit.StaticExpect.Tests/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.7.1.0" newVersion="3.7.1.0" />
+        <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.8.1.0" newVersion="3.8.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/src/NUnit.StaticExpect.Tests/packages.config
+++ b/src/NUnit.StaticExpect.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
-  <package id="NUnit" version="3.7.1" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net461" />
   <package id="PeanutButter.RandomGenerators" version="1.2.162" targetFramework="net452" />
   <package id="PeanutButter.TestUtils.Generic" version="1.2.162" targetFramework="net452" />
   <package id="PeanutButter.Utils" version="1.2.183" targetFramework="net461" />

--- a/src/NUnit.StaticExpect/ExpectationsDoes.cs
+++ b/src/NUnit.StaticExpect/ExpectationsDoes.cs
@@ -20,7 +20,7 @@ namespace NUnit.StaticExpect
         /// Returns a new CollectionContainsConstraint checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static CollectionContainsConstraint Contain(object expected)
+        public static SomeItemsConstraint Contain(object expected)
         {
             return Does.Contain(expected);
         }

--- a/src/NUnit.StaticExpect/ExpectationsHas.cs
+++ b/src/NUnit.StaticExpect/ExpectationsHas.cs
@@ -87,7 +87,7 @@ namespace NUnit.StaticExpect
         /// Returns a new CollectionContainsConstraint checking for the
         /// presence of a particular object in the collection.
         /// </summary>
-        public static Func<object, CollectionContainsConstraint> Member =>
+        public static Func<object, EqualConstraint> Member =>
             Has.Member;
     }
 }

--- a/src/NUnit.StaticExpect/ExpectationsIs.cs
+++ b/src/NUnit.StaticExpect/ExpectationsIs.cs
@@ -176,7 +176,7 @@ namespace NUnit.StaticExpect
         //
         // Remarks:
         //     from must be less than or equal to true
-        public static Func<IComparable, IComparable, RangeConstraint> InRange =>
+        public static Func<Object, Object, RangeConstraint> InRange =>
             Is.InRange;
 
         //
@@ -227,38 +227,6 @@ namespace NUnit.StaticExpect
         //     under an expected path after canonicalization.
         public static Func<string, SamePathOrUnderConstraint> SamePathOrUnder =>
             Is.SamePathOrUnder;
-
-        //        //
-        // Summary:
-        //     Returns a constraint that succeeds if the actual value contains the substring
-        //     supplied as an argument.
-        [Obsolete("Deprecated, use Does.Contain")]
-        public static Func<string, SubstringConstraint> StringContaining =>
-            Is.StringContaining;
-
-        //
-        // Summary:
-        //     Returns a constraint that succeeds if the actual value ends with the substring
-        //     supplied as an argument.
-        [Obsolete("Deprecated, use Does.EndWith")]
-        public static Func<string, EndsWithConstraint> StringEnding =>
-            Is.StringEnding;
-
-        //
-        // Summary:
-        //     Returns a constraint that succeeds if the actual value matches the regular expression
-        //     supplied as an argument.
-        [Obsolete("Deprecated, use Does.Match")]
-        public static Func<string, RegexConstraint> StringMatching =>
-            Is.StringMatching;
-
-        //
-        // Summary:
-        //     Returns a constraint that succeeds if the actual value starts with the substring
-        //     supplied as an argument.
-        [Obsolete("Deprecated, use Does.StartWith")]
-        public static Func<string, StartsWithConstraint> StringStarting =>
-            Is.StringStarting;
 
         //
         // Summary:

--- a/src/NUnit.StaticExpect/ExpectationsMopUp.cs
+++ b/src/NUnit.StaticExpect/ExpectationsMopUp.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using System.Collections;
+
+namespace NUnit.StaticExpect
+{
+    public static partial class Expectations
+    {
+        /// <summary>
+        /// Returns a new ContainsConstraint. This constraint
+        /// will, in turn, make use of the appropriate second-level
+        /// constraint, depending on the type of the actual argument.
+        /// This overload is only used if the item sought is a string,
+        /// since any other type implies that we are looking for a
+        /// collection member.
+        /// </summary>
+        public static ContainsConstraint Contains(string expected)
+        {
+            return new ContainsConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="EqualConstraint"/> checking for the
+        /// presence of a particular object in the collection.
+        /// </summary>
+        public static EqualConstraint Contains(object expected)
+        {
+            return Has.Some.EqualTo(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value contains the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Contains")]
+        public static SubstringConstraint ContainsSubstring(string expected)
+        {
+            return new SubstringConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that fails if the actual
+        /// value contains the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.Not.Contain")]
+        public static SubstringConstraint DoesNotContain(string expected)
+        {
+            return new ConstraintExpression().Not.ContainsSubstring(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that fails if the actual
+        /// value ends with the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.Not.EndWith")]
+        public static EndsWithConstraint DoesNotEndWith(string expected)
+        {
+            return new ConstraintExpression().Not.EndsWith(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that fails if the actual
+        /// value matches the pattern supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.Not.Match")]
+        public static RegexConstraint DoesNotMatch(string pattern)
+        {
+            return new ConstraintExpression().Not.Matches(pattern);
+        }
+
+        /// <summary>
+        /// Returns a constraint that fails if the actual
+        /// value starts with the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.Not.StartWith")]
+        public static StartsWithConstraint DoesNotStartWith(string expected)
+        {
+            return new ConstraintExpression().Not.StartsWith(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value ends with the substring supplied as an argument.
+        /// </summary>
+        public static EndsWithConstraint EndsWith(string expected)
+        {
+            return new EndsWithConstraint(expected);
+        }
+        
+        /// <summary>
+        /// Returns a ListMapper based on a collection.
+        /// </summary>
+        /// <param name="original">The original collection</param>
+        /// <returns></returns>
+        public static ListMapper Map(ICollection original)
+        {
+            return new ListMapper(original);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value matches the regular expression supplied as an argument.
+        /// </summary>
+        public static RegexConstraint Matches(string pattern)
+        {
+            return new RegexConstraint(pattern);
+        }
+
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value starts with the substring supplied as an argument.
+        /// </summary>
+        public static StartsWithConstraint StartsWith(string expected)
+        {
+            return new StartsWithConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value contains the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Contains")]
+        public static SubstringConstraint StringContaining(string expected)
+        {
+            return new SubstringConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value ends with the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.EndWith or EndsWith")]
+        public static EndsWithConstraint StringEnding(string expected)
+        {
+            return new EndsWithConstraint(expected);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value matches the regular expression supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.Match or Matches")]
+        public static RegexConstraint StringMatching(string pattern)
+        {
+            return new RegexConstraint(pattern);
+        }
+
+        /// <summary>
+        /// Returns a constraint that succeeds if the actual
+        /// value starts with the substring supplied as an argument.
+        /// </summary>
+        [Obsolete("Deprecated, use Does.StartWith or StartsWith")]
+        public static StartsWithConstraint StringStarting(string expected)
+        {
+            return new StartsWithConstraint(expected);
+        }
+    }
+}

--- a/src/NUnit.StaticExpect/NUnit.StaticExpect.csproj
+++ b/src/NUnit.StaticExpect/NUnit.StaticExpect.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,6 +47,7 @@
     <Compile Include="Expectations.cs" />
     <Compile Include="ExpectationsHas.cs" />
     <Compile Include="ExpectationsIs.cs" />
+    <Compile Include="ExpectationsMopUp.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnit.StaticExpect/packages.config
+++ b/src/NUnit.StaticExpect/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.1" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
We recently discussed (#1) how `AssertionHelper` implements several members (other than `Expect`) intended to make user's lives a little easier. You very quickly added all of the `Is`, `Does` and `Has` members but there were still a small number missing (the ones we decided no one probably used :)). This PR implements all the rest and beefs up the test suite to ensure that a) everything is covered and b) all the original `AssertionHelper` tests still pass using the new code. In this way, `Expectations` should now be a complete and verifiable drop-in replacement for `AssertionHelper` anywhere it's been used.

There are a few changes here. Please let me know if only some are suitable and I will try to separate them out:

1. New test class: `TestExpect_AssertionHelperCompatibility.cs` checks all static and instance methods and properties from `AssertionHelper` for static implementation on `Expectations`. The full signature is checked when matching.
1. New class `Extensions.cs` in test project. This provides some helper methods on `Type` to ease the checking of compatible member signatures.
1. New partial class `ExpectationsMopUp.cs` implements those members that weren't found by the compatibility test above (just a straight copy and paste from `AssertionHelper.cs`).
1. New test class `TestAssertionHelper_OriginalTests.cs` is a copy and paste from the NUnit test suite of the test class for `AssertionHelper`. It is modified to target `Expectations` instead and runs all the original `AssertionHelper` tests on `Expectations` (they all passed straight off the bat!). It comes with a new folder in the test project, `TestUtilities_Comparers` containing some necessary support code.
1. Project now targets NUnit 3.8.1.

There are a few further notes:

1. Updating to 3.8.1 involved some altered return types and the removal of a few members (already marked "Obsolete") from `ExpectationsIs` that have been culled from `Is`.
1. Two of the tests in `TestExpect_AssertionHelperCompatibility.cs` fail. This is because
   1. The implementation of `Is.InRange()` recently changed its parameter types from `IComparable` to `object` but `Assertionhelper` hasn't yet been amended to keep pace.
   1. `Does.Exactly()` returns a different type to `AssertionHelper.Exactly()`. This difference is apparently older and `AssertionHelper` has never been updated to match.
1. It turns out there are some weaknesses in the implementation of `Type.GetMethod()` (which is used to locate matching methods on `Expectations` to those found on `Assertionhelper`) when it comes to generic parameters. Enough work has been done on a replacement for this to correctly identify all the members currently in `AssertionHelper` (which, let's be honest, are unlikely to change much), but care should be taken using either of the new `Type` extensions in a wider scope.
1. The test classes are more complicated than I'd like. Probably the extension methods in particular should have their own unit tests, but I've already spent longer on this than I intended :) (seemed so straightforward when I looked at it...)
